### PR TITLE
Pipeline and installer tweaks

### DIFF
--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -147,7 +147,7 @@ jobs:
 
             And the SpeckleGSA (https://github.com/arup-group/SpeckleGSA) plugin
           draft: false
-          prerelease: false
+          prerelease: true
 
       - name: Upload Release Asset
         id: upload-release-asset 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The installer does not require admin privileges and auto updates!
 4. Select the `Master` branch
 5. Input the first three digits of the release version in the input box. e.g. `1.8.32`
 6. Press the `Run Workflow` button
+7. Check the created release, if all is well, press the `Edit` button and until the `Pre-release` checkbox
 
 ![gif on how to create a release](https://raw.githubusercontent.com/arup-group/SpeckleInstaller/master/Docs/how-to-make-a-release.gif)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The installer does not require admin privileges and auto updates!
 4. Select the `Master` branch
 5. Input the first three digits of the release version in the input box. e.g. `1.8.32`
 6. Press the `Run Workflow` button
-7. Check the created release, if all is well, press the `Edit` button and until the `Pre-release` checkbox
+7. Download the installer and check the created release
+8. If all is well, press the `Edit` button on the release, unselect the `This is a pre-release` checkbox and press `update release`
 
 ![gif on how to create a release](https://raw.githubusercontent.com/arup-group/SpeckleInstaller/master/Docs/how-to-make-a-release.gif)
 

--- a/SpeckleInstaller.iss
+++ b/SpeckleInstaller.iss
@@ -1,7 +1,7 @@
 ;defining variables
 #define AppName      "Speckle-cx"
 #define AppVersion GetFileVersion("SpeckleUpdater\bin\Release\SpeckleUpdater.exe")
-#define RhinoVersion  GetFileVersion("SpeckleRhino\SpeckleRhinoConverter.dll")
+#define RhinoVersion  GetFileVersion("SpeckleRhino\SpeckleWinR6.rhp")
 #define DynamoVersion  GetFileVersion("SpeckleDynamo\bin\SpeckleDynamo.dll")
 #define RevitVersion  GetFileVersion("SpeckleRevit2021\SpeckleRevit\SpeckleRevit.dll")
 #define CoreGeometryVersion  GetFileVersion("SpeckleCoreGeometry\SpeckleCoreGeometry.dll")


### PR DESCRIPTION
Hi @peterjgrainger, this is a short PR that makes two changes:

1. the installer now checks the correct file for the Rhino/Grasshopper version (bug we inherited from the original installer)
2. the github action for creating a release now marks it as pre-release. This lets us test the artifact before it starts getting auto downloaded...