### PR TITLE
[SPEC-260] Add analytics to the installer and setup telemetry

### DIFF
--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -35,6 +35,14 @@ jobs:
         
       - name: Compile Speckle Updater in Release configuration
         run: msbuild SpeckleUpdater.sln /property:Configuration=Release
+
+      - name: Analytics CLI - Restore NuGets
+        run: dotnet restore
+        working-directory: Analytics
+
+      - name: Analytics CLI - Compile CLI
+        run: dotnet build --configuration Release --runtime win-x64
+        working-directory: Analytics
         
       - uses: i3h/download-release-asset@v1
         name: Download Rhino from Arup Group GitHub org
@@ -114,6 +122,8 @@ jobs:
 
       - name: create Installer
         run: iscc /dAppVersion="${{ steps.calculateTagVersion.outputs.tag }}" SpeckleInstaller.iss
+        env:
+          ENABLE_TELEMETRY_DOMAIN: ${{ secrets.ENABLE_TELEMETRY_DOMAIN }}
 
       - name: Get Signing Certificate
         run: |
@@ -131,6 +141,13 @@ jobs:
         run: |
           Set-Alias signtool "C:/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64/signtool.exe"
           signtool sign /v /f signing.pfx /p "${{ secrets.SIGNING_CERT_PASSWORD }}" /fd sha256 /tr http://rfc3161timestamp.globalsign.com/advanced /td sha256 /d Speckle ${{ steps.listName.outputs.filename }}
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.listName.outputs.filename }}
+          path: ${{ steps.listName.outputs.filename }}
+          retention-days: 1
 
       - name: Create Release
         id: create-release
@@ -166,4 +183,3 @@ jobs:
           asset_path: ./${{ steps.listName.outputs.filename }}
           asset_name: ${{ steps.listName.outputs.filename }}
           asset_content_type: application/vnd.microsoft.portable-executable
-

--- a/Analytics/Program.cs
+++ b/Analytics/Program.cs
@@ -1,0 +1,32 @@
+﻿using Piwik.Tracker;
+using System.Runtime.InteropServices;
+using System;
+using SpeckleCore;
+using System.Globalization;
+
+namespace analytics
+{
+    class Program
+    {
+        private static readonly string PiwikBaseUrl = "https://arupdt.matomo.cloud/";
+        private static readonly int SiteId = 1;
+
+        static void Main(string[] args)
+        {
+            var _piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
+            var _action = args[0];
+            var _version = args[1];
+            var _domain = args[2];
+            var _machineName = Environment.MachineName.ToLower(new CultureInfo("en-GB", false));
+            // Only track users from specific domains (not general public)
+            if(_machineName.Contains(_domain)) {
+                // Set telemetry to true in the database
+                LocalContext.Init();
+                LocalContext.SetTelemetrySettings(true);
+                // Send this information to Matomo
+                _piwikTracker.DoTrackEvent("SpeckleInstaller", _action, _version); 
+            }
+        }
+
+    }
+}

--- a/Analytics/Program.cs
+++ b/Analytics/Program.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 using System;
 using SpeckleCore;
 using System.Globalization;
+using System.Diagnostics;
+using System.IO;
 
 namespace analytics
 {
@@ -13,18 +15,22 @@ namespace analytics
 
         static void Main(string[] args)
         {
-            var _piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
-            var _action = args[0];
-            var _version = args[1];
-            var _domain = args[2];
-            var _machineName = Environment.MachineName.ToLower(new CultureInfo("en-GB", false));
+            PiwikTracker _piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
+            String _version = args[0];
+            String _allowedDomain = args[1];
+            String _machineName = Environment.MachineName.ToLower(new CultureInfo("en-GB", false));            
+            String _appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            String _speckleUpdaterExe = _appDataFolder + "\\Speckle\\SpeckleUpdater.exe";
+
+            // Check to see if this is an update or it's a new user.
+            String _installType = File.Exists(_speckleUpdaterExe) ? "update" : "new";
+            
             // Only track users from specific domains (not general public)
-            if(_machineName.Contains(_domain)) {
-                // Set telemetry to true in the database
-                LocalContext.Init();
+            if(_machineName.Contains(_allowedDomain)) {
+                // Sets a flag in the cache database. Used by clients.
                 LocalContext.SetTelemetrySettings(true);
                 // Send this information to Matomo
-                _piwikTracker.DoTrackEvent("SpeckleInstaller", _action, _version); 
+                _piwikTracker.DoTrackEvent("SpeckleInstaller", _installType, _version); 
             }
         }
 

--- a/Analytics/Program.cs
+++ b/Analytics/Program.cs
@@ -1,9 +1,7 @@
 ﻿using Piwik.Tracker;
-using System.Runtime.InteropServices;
 using System;
 using SpeckleCore;
 using System.Globalization;
-using System.Diagnostics;
 using System.IO;
 
 namespace analytics
@@ -12,18 +10,18 @@ namespace analytics
     {
         private static readonly string PiwikBaseUrl = "https://arupdt.matomo.cloud/";
         private static readonly int SiteId = 1;
+        private static readonly string CacheLocation = "\\SpeckleSettings\\SpeckleCache.db";
 
         static void Main(string[] args)
         {
             PiwikTracker _piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
-            String _version = args[0];
-            String _allowedDomain = args[1];
-            String _machineName = Environment.MachineName.ToLower(new CultureInfo("en-GB", false));            
-            String _appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            String _speckleUpdaterExe = _appDataFolder + "\\Speckle\\SpeckleUpdater.exe";
+            string _version = args[0];
+            string _allowedDomain = args[1];
+            string _machineName = Environment.MachineName.ToLower(new CultureInfo("en-GB", false));            
+            string _appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
             // Check to see if this is an update or it's a new user.
-            String _installType = File.Exists(_speckleUpdaterExe) ? "update" : "new";
+            string _installType = File.Exists(_appDataFolder + CacheLocation) ? "update" : "new";
             
             // Only track users from specific domains (not general public)
             if(_machineName.Contains(_allowedDomain)) {

--- a/Analytics/Program.cs
+++ b/Analytics/Program.cs
@@ -3,6 +3,8 @@ using System;
 using SpeckleCore;
 using System.Globalization;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace analytics
 {
@@ -16,21 +18,39 @@ namespace analytics
         {
             PiwikTracker _piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
             string _version = args[0];
-            string _allowedDomain = args[1];
+            string _internalDomain = args[1];
             string _machineName = Environment.MachineName.ToLower(new CultureInfo("en-GB", false));            
             string _appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-            // Check to see if this is an update or it's a new user.
+            // If the cache has been set up this is an update, otherwise it's a new user
             string _installType = File.Exists(_appDataFolder + CacheLocation) ? "update" : "new";
+
+            bool _isInternalDomain = _machineName.Contains(_internalDomain);
+
+            // Don't collect telemetry except for users on the internal domain.
+            LocalContext.SetTelemetrySettings(_isInternalDomain);
             
-            // Only track users from specific domains (not general public)
-            if(_machineName.Contains(_allowedDomain)) {
-                // Sets a flag in the cache database. Used by clients.
-                LocalContext.SetTelemetrySettings(true);
+            if(_isInternalDomain) {
+                // Hash the username and send it with the installer info
+                _piwikTracker.SetUserId(ComputeSHA256Hash(Environment.UserName + "@" + _internalDomain + ".com"));
+
                 // Send this information to Matomo
                 _piwikTracker.DoTrackEvent("SpeckleInstaller", _installType, _version); 
             }
         }
 
+        /**
+        * Perform a one-way hash of the input text.
+        **/
+        private static string ComputeSHA256Hash(string text)
+        {
+            using (var sha256 = new SHA256Managed())
+            {
+                byte[] _encodedText = Encoding.UTF8.GetBytes(text);
+                byte[] _hash = sha256.ComputeHash(_encodedText);
+                string _hashString = BitConverter.ToString(_hash);
+                return _hashString.Replace("-", "").ToLower(new CultureInfo("en-GB", false));
+            }                
+        }
     }
 }

--- a/Analytics/analytics.csproj
+++ b/Analytics/analytics.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Piwik.Tracker" Version="3.0.0" />
+    <PackageReference Include="SpeckleCore" Version="1.8.3.463" />
+  </ItemGroup>
+
+</Project>

--- a/SpeckleInstaller.iss
+++ b/SpeckleInstaller.iss
@@ -10,8 +10,10 @@
 #define SpeckleGSAVersion  GetFileVersion("SpeckleGSA\SpeckleGSA.dll")
 #define AppPublisher "Speckle-cx"
 #define AppURL       "https://speckle.works"
-#define SpeckleFolder "{localappdata}\Speckle"      
+#define SpeckleFolder "{localappdata}\Speckle" 
+#define AnalyticsFolder "{localappdata}\SpeckleAnalytics"      
 #define UpdaterFilename       "SpeckleUpdater.exe"
+#define AnalyticsFilename       "analytics.exe"
 
 [Setup]
 AppId={{BA3A01AA-F70D-4747-AA0E-E93F38C793C8}
@@ -67,6 +69,9 @@ Name: "{app}"; Permissions: everyone-full
 [Files]
 ;updater
 Source: "SpeckleUpdater\bin\Release\*"; DestDir: "{#SpeckleFolder}"; Flags: ignoreversion recursesubdirs;
+
+;analytics
+Source: "Analytics\bin\Release\net45\win-x64\*"; DestDir: "{#AnalyticsFolder}"; Flags: ignoreversion recursesubdirs;
 
 ;rhino+gh                                                                                                                                      
 Source: "SpeckleRhino\*"; DestDir: "{userappdata}\McNeel\Rhinoceros\6.0\Plug-ins\Speckle Rhino Plugin (512d9705-6f92-49ca-a606-d6d5c1ac6aa2)\{#RhinoVersion}"; Flags: ignoreversion recursesubdirs; Components: gh  
@@ -126,6 +131,7 @@ Type: filesandordirs; Name: "{localappdata}\SpeckleKits\SpeckleElements\*"
 Type: filesandordirs; Name: "{localappdata}\SpeckleKits\SpeckleStructural\*"
 Type: filesandordirs; Name: "{localappdata}\SpeckleGSA\*"
 Type: filesandordirs; Name: "{localappdata}\Speckle\*"
+Type: filesandordirs; Name: "{localappdata}\SpeckleAnalytics\*"
 
 [Registry]
 Root: HKCU; Subkey: "SOFTWARE\McNeel\Rhinoceros\6.0\Plug-ins\512d9705-6f92-49ca-a606-d6d5c1ac6aa2"; ValueType: string; ValueName: "Name"; ValueData: "Speckle";
@@ -138,6 +144,9 @@ Name: "{userappdata}\Microsoft\Windows\Start Menu\Programs\Startup\Speckle"; Fil
 Name: "{userappdata}\Microsoft\Windows\Start Menu\Programs\Oasys\SpeckleGSA"; Filename: "{localappdata}\SpeckleGSA\SpeckleGSAUI.exe";
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 ;Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{#AnalyticsFolder}\analytics.exe"; Parameters: "installed {#AppVersion} {#GetEnv('ENABLE_TELEMETRY_DOMAIN')}"; Description: "Send anonymous analytics to Arup. No project data or personally identifiable information will be sent."
 
 ;checks if minimun requirements are met
 [Code]

--- a/SpeckleInstaller.iss
+++ b/SpeckleInstaller.iss
@@ -146,7 +146,7 @@ Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 ;Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{#AnalyticsFolder}\analytics.exe"; Parameters: "installed {#AppVersion} {#GetEnv('ENABLE_TELEMETRY_DOMAIN')}"; Description: "Send anonymous analytics to Arup. No project data or personally identifiable information will be sent."
+Filename: "{#AnalyticsFolder}\analytics.exe"; Parameters: "{#AppVersion} {#GetEnv('ENABLE_TELEMETRY_DOMAIN')}"; Description: "Send anonymous analytics to Arup. No project data or personally identifiable information will be sent."
 
 ;checks if minimun requirements are met
 [Code]


### PR DESCRIPTION
- Created a dotnet core cli targeting .Net 4.5 (same as speckle core)
- Accepts three arguments `version` `domain` e.g. `1.0.10.32423` `my-domain`
- Checks if the file SpeckleUpdater.exe exists. If so, this is an update not a new install
- Call this CLI after installation and only for the supplied domain on installer creation time (allowed domain is stored in secrets)
- Update the SQLite database and set telemetry to true so clients know if to send telemetry 

@daviddekoning @jenessaman please check my c#. It's my first .net core program :)

Can view the data like this
![image](https://user-images.githubusercontent.com/1332395/111975888-fd3ba880-8af8-11eb-9a84-06f4bf7e69d9.png)

