### PR TITLE
Use EV cert to sign installer

### DIFF
--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -15,6 +15,7 @@ jobs:
   installer:
     runs-on: windows-latest
     steps:
+      
       - name: Check out repository
         uses: actions/checkout@v2
         
@@ -154,21 +155,30 @@ jobs:
         env:
           ENABLE_TELEMETRY_DOMAIN: ${{ secrets.ENABLE_TELEMETRY_DOMAIN }}
           
-      - name: Get Signing Certificate
-        run: |
-          [IO.File]::WriteAllBytes('signing.pfx', [Convert]::FromBase64String("${{ secrets.SIGNING_CERT }}"))
       - name: Get Name of exe file
         id: listName
         shell: powershell
         run: |
           $filename = (ls *.exe).Name
           echo "::set-output name=filename::$filename"
+
+    
+      - name: Install Azure Key Vault signtool
+        run: dotnet tool install --global AzureSignTool --version 2.0.17
           
+      # https://github.com/vcsjones/AzureSignTool
       - name: Sign Installer
         shell: powershell
         run: |
-          Set-Alias signtool "C:/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64/signtool.exe"
-          signtool sign /v /f signing.pfx /p "${{ secrets.SIGNING_CERT_PASSWORD }}" /fd sha256 /tr http://rfc3161timestamp.globalsign.com/advanced /td sha256 /d Speckle ${{ steps.listName.outputs.filename }}
+          AzureSignTool sign `
+            --description-url "https://speckle.arup.com" `
+            --azure-key-vault-url "https://oasysevkv.vault.azure.net/" `
+            --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" `
+            --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" `
+            --azure-key-vault-certificate "OasysCodeSigning" `
+            --timestamp-rfc3161 "http://timestamp.digicert.com" `
+            --verbose `
+            ${{ github.workspace }}\${{ steps.listName.outputs.filename }}
       
       - name: Upload a Build Artifact      
         uses: actions/upload-artifact@v2
@@ -187,8 +197,6 @@ jobs:
           tag_name: ${{ steps.calculateTagVersion.outputs.tag }}
           release_name: Speckle-cx Installer ${{ steps.calculateTagVersion.outputs.tag }}
           body: |
-            On installation of ${{ steps.listName.outputs.filename }} you may get a warning screen from Windows Defender due to the executable being downloaded from the internet. It is safe to ignore this message and continue installation.
-            
             Speckle-cx installer includes the following versions of the following SpeckleKits:
             
             - [SpeckleCoreGeometry ${{ steps.releaseVersions.outputs.coreGeometry }}](https://github.com/arup-group/SpeckleCoreGeometry/releases/tag/${{ steps.releaseVersions.outputs.coreGeometry }})


### PR DESCRIPTION
Use an EV cert for the installer.

This stops windows defender from popping up warning the program is not safe to install

![Screenshot 2021-05-24 at 20 57 47](https://user-images.githubusercontent.com/1332395/119401503-7d39e680-bcd3-11eb-9b20-49db29b0ce88.png)
